### PR TITLE
README.md: add more info about the sprints and related projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,95 @@
 # Sprints de Inovacao Cívica no Brasil
 
-Neste repositório encontram-se os relatórios e históricos dos sprints realizados pelas cidades do Brasil, com o foco em projetos de inovação cívica.
+O objetivo das sprints de inovação cívica é aproximar pessoas interessadas
+em contribuir nos projetos relacinados a Operação Serenata de amor . Cada 
+Sprint é um ambiente comunitário, para o desenvolvimento e contribuição de 
+projetos abertos. Dessa forma, todas as pessoas serão bem vindas, ou seja, 
+desde iniciantes e curiosos até pessoas com o mais amplo domínio de 
+conhecimento sobre o projeto.
+
+# Operação Serenata de amor
+
+A Operação Serenata de amor é projeto aberto que usa ciência de dados com a 
+finalidade de fiscalizar gastos públicos e compartilhar as informações de 
+forma acessível a qualquer pessoa.
+
+A Serenata criou a Rosie: uma inteligência artificial capaz de analisar os 
+gastos reembolsados pela Cota para Exercício da Atividade Parlamentar (CEAP), 
+de deputados federais e senadores, feitos em exercício de sua função, 
+identificando suspeitas e incentivando a população a questioná-los.
+
+Atualmente, queremos expandir o projeto, ensinando coisas novas para a Rosie e 
+a adaptando para outras esferas, como as câmaras municipais. Nossa meta é 
+levar mais informação para a população, transformando os dados públicos em 
+conteúdo acessível por meio das nossas redes e por meio da produção 
+independente de conteúdo.
+
+# Diário Oficial 
+
+O Diário Oficial é o diário do governo brasileiro, um dos melhores lugares 
+para conhecer as últimas ações da administração pública, com publicações 
+distintas nos níveis federal, estadual e municipal.
+
+Mesmo com os esforços recorrentes de impor a legislação de Liberdade de 
+Informação em todo o país, a comunicação oficial permanece - na maioria 
+dos territórios - em PDFs.a O objetivo do projeto é atualizar as informações 
+dos Diários Oficiais, disponibilizando informações de forma acessível.
+
+# Será que eu consigo contribuir?
+
+Sim, consegue! Existem tarefas com diferentes graus de dificuldade, então mesmo 
+que você seja iniciante em programação, é possível ajudar com código, 
+documentação ou mesmo com novas ideias para o projeto. Acompanhar 
+desenvolvedores mais experientes também é uma ótima forma de aprender.
+
+Principais Repositórios
+* https://github.com/okfn-brasil/serenata-de-amor
+* https://github.com/okfn-brasil/notebooks
+* https://github.com/okfn-brasil/diario-oficial
+
+# Programação
+
+A sugestão é iniciar o evento em uma sexta feira de noite com uma palestra 
+inicial apresentando os projetos e explicando a dinâmica do Sprint. Além disso, 
+na parte final ter um momento de preparação de ambiente e instalação de 
+dependências nos notebooks dos participantes, chamamos essa etapa de 
+*install fest*.  Ademais, a continuação dos trabalhos pode ser feita durante 
+todo o dia de sábado com as atividades de “mão na massa”.
+
+## Template: 
+
+- Sexta-feira
+	- 19h - Abertura
+	- 19h30m - Informações e status dos projetos de inovação cívica (serenata e diário oficial)
+	- 20h - Configuração de ambiente - install fest
+- Sábado
+	- Sprint durante todo o dia.
+
+# Informações gerais
+
+* Pedir a todos: Levem Notebooks, extensão de energia e essas coisas :-)
+* É interessante a equipe de organização criar um grupo no Telegram para
+compartilhar materiais, avisos e também para os participantes trocarem ideias.
+
+# Relatórios
+
+Neste repositório encontram-se os relatórios e históricos dos sprints 
+realizados pelas cidades do Brasil, com o foco em projetos de inovação cívica.
 
 As pastas estão organizadas de acordo com o seguinte padrão: `estado, data e cidade`:
 
 **ESTADO/yyyy-mm-dd-CIDADE.md**
 
-Em cada pasta encontram-se um relatório escrito no padrão markdown com as seguintes informações:
+Em cada pasta encontram-se um relatório escrito no padrão markdown com as 
+seguintes informações:
 
 * Número de participantes;
 * Informações de local e horários da realização do evento;
 * Fotos das atividades;
-* Links para os projetos de código aberto que receberam contribuiçes durante o Sprint;
-* Um resumo das principais contribuições, com links para eventuais issues e pull requests que fora propostos;
+* Links para os projetos de código aberto que receberam contribuiçes durante 
+o Sprint;
+* Um resumo das principais contribuições, com links para eventuais issues e 
+pull requests que fora propostos;
 * Por fim, uma sessão com feedbacks dos participantes;
 
 ## Sprints já realizados


### PR DESCRIPTION
Adds more documentation about the sprint goals and related projects.
Furthermore, the README.md contains the template that can be followed
by whom it's organizing a sprint

Signed-off-by: José Guilherme Vanz <jvanz@jvanz.com>